### PR TITLE
Update route.js to be "force-dynamic"

### DIFF
--- a/src/app/try/route.js
+++ b/src/app/try/route.js
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 const localExecutablePath =
   process.platform === "win32"
     ? "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"


### PR DESCRIPTION
Without this, the `/try` route is statically rendered during build and is directly serving the screenshot image, without taking any screenshot during runtime.

I spent an hour debugging why this route was so fast on production when it was much slower on development and finally realized it was directly serving the image generated at build time 😭 